### PR TITLE
make comments default; no space required for self-closing tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,11 +75,11 @@ module.exports = function (h, opts) {
         for (; i < parts.length; i++) {
           if (parts[i][0] === ATTR_VALUE || parts[i][0] === ATTR_KEY) {
             if (!cur[1][key]) cur[1][key] = strfn(parts[i][1])
-            else cur[1][key] = concat(cur[1][key], parts[i][1])
+            else parts[i][1]==="" || (cur[1][key] = concat(cur[1][key], parts[i][1]))
           } else if (parts[i][0] === VAR
           && (parts[i][1] === ATTR_VALUE || parts[i][1] === ATTR_KEY)) {
             if (!cur[1][key]) cur[1][key] = strfn(parts[i][2])
-            else cur[1][key] = concat(cur[1][key], parts[i][2])
+            else parts[i][2]==="" || (cur[1][key] = concat(cur[1][key], parts[i][2]))
           } else {
             if (key.length && !cur[1][key] && i === j
             && (parts[i][0] === CLOSE || parts[i][0] === ATTR_BREAK)) {
@@ -176,6 +176,7 @@ module.exports = function (h, opts) {
         } else if (state === TEXT || state === COMMENT) {
           reg += c
         } else if (state === OPEN && c === '/' && reg.length) {
+          console.log('foo')
           // no-op, self closing tag without a space (e.g. <br/>)
         } else if (state === OPEN && /\s/.test(c)) {
           res.push([OPEN, reg])

--- a/index.js
+++ b/index.js
@@ -166,19 +166,17 @@ module.exports = function (h, opts) {
           reg = ''
           state = TEXT
         } else if (state === COMMENT && /-$/.test(reg) && c === '-') {
-          if (opts.comments) {
-            res.push([ATTR_VALUE,reg.substr(0, reg.length - 1)],[CLOSE])
-          }
+          res.push([ATTR_VALUE,reg.substr(0, reg.length - 1)],[CLOSE])
           reg = ''
           state = TEXT
         } else if (state === OPEN && /^!--$/.test(reg)) {
-          if (opts.comments) {
-            res.push([OPEN, reg],[ATTR_KEY,'comment'],[ATTR_EQ])
-          }
+          res.push([OPEN, reg],[ATTR_KEY,'comment'],[ATTR_EQ])
           reg = c
           state = COMMENT
         } else if (state === TEXT || state === COMMENT) {
           reg += c
+        } else if (state === OPEN && c === '/' && reg.length) {
+          // no-op, self closing tag without a space (e.g. <br/>)
         } else if (state === OPEN && /\s/.test(c)) {
           res.push([OPEN, reg])
           reg = ''

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var ATTR_KEY = 5, ATTR_KEY_W = 6
 var ATTR_VALUE_W = 7, ATTR_VALUE = 8
 var ATTR_VALUE_SQ = 9, ATTR_VALUE_DQ = 10
 var ATTR_EQ = 11, ATTR_BREAK = 12
-var COMMENT = 13
+var COMMENT = 13, SELF_CLOSE = 14
 
 module.exports = function (h, opts) {
   if (!opts) opts = {}
@@ -98,13 +98,12 @@ module.exports = function (h, opts) {
       } else if (s === VAR && p[1] === ATTR_KEY) {
         cur[1][p[2]] = true
       } else if (s === CLOSE) {
-        if (selfClosing(cur[0]) && stack.length) {
-          var ix = stack[stack.length-1][1]
-          stack.pop()
-          stack[stack.length-1][0][2][ix] = h(
-            cur[0], cur[1], cur[2].length ? cur[2] : undefined
-          )
-        }
+      } else if (s === SELF_CLOSE) {
+        var ix = stack[stack.length-1][1]
+        stack.pop()
+        stack[stack.length-1][0][2][ix] = h(
+          cur[0], cur[1], cur[2].length ? cur[2] : undefined
+        )
       } else if (s === VAR && p[1] === TEXT) {
         if (p[2] === undefined || p[2] === null) p[2] = ''
         else if (!p[2]) p[2] = concat('', p[2])
@@ -147,6 +146,14 @@ module.exports = function (h, opts) {
           if (reg.length) res.push([TEXT, reg])
           reg = ''
           state = OPEN
+        } else if (c === '>' && str.charAt(i - 1) === '/') {
+          res.push([SELF_CLOSE])
+          reg = ''
+          state = TEXT
+        } else if (c === '>' && str.charAt(i - 1) === '-' && str.charAt(i - 2) === '-') {
+          res.push([SELF_CLOSE])
+          reg = ''
+          state = TEXT
         } else if (c === '>' && !quot(state) && state !== COMMENT) {
           if (state === OPEN) {
             res.push([OPEN,reg])
@@ -261,21 +268,3 @@ function quot (state) {
 
 var hasOwn = Object.prototype.hasOwnProperty
 function has (obj, key) { return hasOwn.call(obj, key) }
-
-var closeRE = RegExp('^(' + [
-  'area', 'base', 'basefont', 'bgsound', 'br', 'col', 'command', 'embed',
-  'frame', 'hr', 'img', 'input', 'isindex', 'keygen', 'link', 'meta', 'param',
-  'source', 'track', 'wbr', '!--',
-  // SVG TAGS
-  'animate', 'animateTransform', 'circle', 'cursor', 'desc', 'ellipse',
-  'feBlend', 'feColorMatrix', 'feComposite',
-  'feConvolveMatrix', 'feDiffuseLighting', 'feDisplacementMap',
-  'feDistantLight', 'feFlood', 'feFuncA', 'feFuncB', 'feFuncG', 'feFuncR',
-  'feGaussianBlur', 'feImage', 'feMergeNode', 'feMorphology',
-  'feOffset', 'fePointLight', 'feSpecularLighting', 'feSpotLight', 'feTile',
-  'feTurbulence', 'font-face-format', 'font-face-name', 'font-face-uri',
-  'glyph', 'glyphRef', 'hkern', 'image', 'line', 'missing-glyph', 'mpath',
-  'path', 'polygon', 'polyline', 'rect', 'set', 'stop', 'tref', 'use', 'view',
-  'vkern'
-].join('|') + ')(?:[\.#][a-zA-Z0-9\u007F-\uFFFF_:-]+)*$')
-function selfClosing (tag) { return closeRE.test(tag) }

--- a/test/br.js
+++ b/test/br.js
@@ -1,0 +1,11 @@
+var test = require('tape')
+var vdom = require('virtual-dom')
+var hyperx = require('../')
+var hx = hyperx(vdom.h)
+
+test('self closing tags without a space', function (t) {
+  var tree = hx`
+    <div><br/><img src="boop"/></div>`
+  t.equal(vdom.create(tree).toString(), '<div>a<br />b<img src="boop" /></div>')
+  t.end()
+})

--- a/test/comment.js
+++ b/test/comment.js
@@ -1,7 +1,6 @@
 var test = require('tape')
 var hyperx = require('../')
 var hx = hyperx(createElement)
-var hxc = hyperx(createElement, {comments: true})
 
 function createElement(tag, props, children) {
   if (tag === '!--') {
@@ -11,19 +10,19 @@ function createElement(tag, props, children) {
 }
 
 test('1 comment', function (t) {
-  var tree = hxc`<!-- test -->`
+  var tree = hx`<!-- test -->`
   t.equal(tree, '<!-- test -->')
   t.end()
 })
 
 test('with crazy characters', function (t) {
-  var tree = hxc`<!-- .-_<>|[]{}"' -->`
+  var tree = hx`<!-- .-_<>|[]{}"' -->`
   t.equal(tree, '<!-- .-_<>|[]{}"\' -->')
   t.end()
 })
 
 test('as child', function (t) {
-  var tree = hxc`<div><!-- child --></div>`
+  var tree = hx`<div><!-- child --></div>`
   t.equal(tree, '<div><!-- child --></div>')
   t.end()
 })
@@ -34,18 +33,12 @@ test('many comments', function (t) {
     <span>bar</span>
     <!-- baz -->
   </div>`
-  var tree = hxc`
+  var tree = hx`
   <div>
     <!-- foo -->
     <span>bar</span>
     <!-- baz -->
   </div>`
   t.equal(tree, html)
-  t.end()
-})
-
-test('excluded by default', function (t) {
-  var tree = hx`<div><!-- comment --></div>`
-  t.equal(tree, '<div></div>')
   t.end()
 })

--- a/test/empty.js
+++ b/test/empty.js
@@ -1,0 +1,16 @@
+var test = require('tape')
+var vdom = require('virtual-dom')
+var hyperx = require('../')
+var hx = hyperx(vdom.h)
+
+test('self closing tag should close', function (t) {
+  var tree = hx`<div>Hello <br /> World</div>`
+  t.equal(vdom.create(tree).toString(), '<div>Hello <br /> World</div>')
+  t.end()
+})
+
+test('custom self closing tag should close', function (t) {
+  var tree = hx`<div><self-closing-tag />Hello World</div>`
+  t.equal(vdom.create(tree).toString(), '<div><self-closing-tag></self-closing-tag>Hello World</div>')
+  t.end()
+})

--- a/test/key.js
+++ b/test/key.js
@@ -63,10 +63,3 @@ test('multiple keys dont overwrite existing ones', function (t) {
   t.equal(vdom.create(tree).toString(), '<input type="date" />')
   t.end()
 })
-
-// https://github.com/choojs/hyperx/issues/55
-test('unquoted key does not make void element eat adjacent elements', function (t) {
-  var tree = hx`<span><input type=text>sometext</span>`
-  t.equal(vdom.create(tree).toString(), '<span><input type="text" />sometext</span>')
-  t.end()
-})


### PR DESCRIPTION
## Summary
Comments should be allowed by default. I don't know why we wouldn't. If it turns out they should be turned off, we should allow an option to turn them off. 

## Misc Changes
Also included in this PR are relevant commits merged in to [choojs/hyperx](https://github.com/choojs/hyperx)
- https://github.com/choojs/hyperx/commit/ee324d98fe4029452c6e7283e35da340f0656951
- https://github.com/choojs/hyperx/commit/380eb374b9c445ac5f884470fc2be48ed1a7ad34

## Tests
- [ ] all existing tests pass
- [x] comment tests have been updated to not use the option